### PR TITLE
[Be/feature/auth] Spring Security 기반 OAuth2 및 JWT 인증/인가 기능 구현

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -1,3 +1,6 @@
+### OAuth ###
+application-oauth.yml
+
 HELP.md
 .gradle
 build/

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -32,8 +32,7 @@ dependencies {
 
 	/* Database */
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.h2database:h2'
-	/*runtimeOnly 'com.mysql:mysql-connector-j'*/
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	/* jwt */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/be/src/main/java/com/sharetravel/ServerApplication.java
+++ b/be/src/main/java/com/sharetravel/ServerApplication.java
@@ -1,8 +1,10 @@
-package com.sharetravel.server;
+package com.sharetravel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing // JPA Auditing 활성화
 @SpringBootApplication
 public class ServerApplication {
 

--- a/be/src/main/java/com/sharetravel/domain/user/controller/UserController.java
+++ b/be/src/main/java/com/sharetravel/domain/user/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.sharetravel.domain.user.controller;
+
+import com.sharetravel.domain.user.dto.UserResponseDto;
+import com.sharetravel.domain.user.dto.UserUpdateRequestDto;
+import com.sharetravel.domain.user.service.UserService;
+import com.sharetravel.global.ApiResponseCode;
+import com.sharetravel.global.ApiResponseMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/api/users")
+    public UserResponseDto find(@AuthenticationPrincipal Long userId) {
+        return userService.findById(userId);
+    }
+
+    @PatchMapping("/api/users")
+    public UserResponseDto update(@AuthenticationPrincipal Long userId, @Valid @RequestBody UserUpdateRequestDto request) {
+        return userService.update(userId, request);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponseMessage> handleInvalidTokenException() {
+        ApiResponseCode apiResponseCode = ApiResponseCode.USER_NOT_FOUND;
+        ApiResponseMessage apiResponseMessage = ApiResponseMessage.of(apiResponseCode.getCode(), apiResponseCode.getMessage());
+        return ResponseEntity.status(apiResponseCode.getHttpStatusCode()).body(apiResponseMessage);
+    }
+
+    // TODO : 사용자 닉네임이 등록되지 않은 경우 클라이언트는 사용자가 닉네임을 등록하도록 하고 서버는 클라이언트로부터 사용자 닉네임을 받아 등록
+    // TODO : 회원 탈퇴 기능(구글 SMTP)
+}

--- a/be/src/main/java/com/sharetravel/domain/user/dto/UserResponseDto.java
+++ b/be/src/main/java/com/sharetravel/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,23 @@
+package com.sharetravel.domain.user.dto;
+
+import com.sharetravel.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserResponseDto {
+
+    private Long userId;
+    private String name;
+    private String nickName;
+    private String email;
+    private String picture;
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(user.getId(), user.getName(), user.getNickName(), user.getEmail(), user.getPicture());
+    }
+}

--- a/be/src/main/java/com/sharetravel/domain/user/dto/UserUpdateRequestDto.java
+++ b/be/src/main/java/com/sharetravel/domain/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.sharetravel.domain.user.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserUpdateRequestDto {
+
+    @Size(min = 6)
+    @Size(max = 30)
+    private String nickName;
+    private String picture;
+}

--- a/be/src/main/java/com/sharetravel/domain/user/entity/Role.java
+++ b/be/src/main/java/com/sharetravel/domain/user/entity/Role.java
@@ -1,0 +1,16 @@
+package com.sharetravel.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+}

--- a/be/src/main/java/com/sharetravel/domain/user/entity/User.java
+++ b/be/src/main/java/com/sharetravel/domain/user/entity/User.java
@@ -1,0 +1,71 @@
+package com.sharetravel.domain.user.entity;
+
+import com.sharetravel.global.BaseTimeEntity;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2Provider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "`user`", indexes = @Index(name = "index_email_provider", columnList = "email, provider", unique = true))
+@Entity
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(length = 30, name = "nickname")
+    private String nickName;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(length = 500, name = "picture")
+    private String picture;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuth2Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public User(String name, String nickName, String email, String picture,
+        OAuth2Provider provider, Role role) {
+        this.name = name;
+        this.nickName = nickName;
+        this.email = email;
+        this.picture = picture;
+        this.provider = provider;
+        this.role = role;
+    }
+
+    public User update(String name, String picture) {
+        this.name = name;
+        this.picture = picture;
+
+        return this;
+    }
+
+    public String getRoleKey() {
+        return this.role.getKey();
+    }
+}

--- a/be/src/main/java/com/sharetravel/domain/user/repository/UserRepository.java
+++ b/be/src/main/java/com/sharetravel/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.sharetravel.domain.user.repository;
+
+import com.sharetravel.domain.user.entity.User;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2Provider;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmailAndProvider(String email, OAuth2Provider provider);
+}

--- a/be/src/main/java/com/sharetravel/domain/user/service/UserService.java
+++ b/be/src/main/java/com/sharetravel/domain/user/service/UserService.java
@@ -1,0 +1,38 @@
+package com.sharetravel.domain.user.service;
+
+import com.sharetravel.domain.user.dto.UserResponseDto;
+import com.sharetravel.domain.user.dto.UserUpdateRequestDto;
+import com.sharetravel.domain.user.entity.User;
+import com.sharetravel.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponseDto findById(Long id) {
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> {
+                throw new IllegalStateException("식별 번호가 " + id + "에 해당되는 사용자가 없습니다.");
+            });
+
+        return UserResponseDto.from(user);
+    }
+
+    @Transactional
+    public UserResponseDto update(Long id, UserUpdateRequestDto request) {
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> {
+                throw new IllegalStateException("식별 번호가 " + id + "에 해당되는 사용자가 없습니다.");
+            });
+
+        user.update(request.getNickName(), request.getPicture());
+
+        return UserResponseDto.from(user);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
+++ b/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
@@ -1,0 +1,23 @@
+package com.sharetravel.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApiResponseCode {
+
+    OAUTH2_LOGIN_SUCCESS("A01", 200, "로그인이 완료되었습니다."),
+    OAUTH2_LOGIN_FAIL("A02", 401, "로그인이 실패했습니다."),
+    TOKEN_INVALID("A03", 401, "유효하지 않은 토큰입니다."),
+    TOKEN_HACKED("A04", 401, "토큰 도용이 의심됩니다."),
+
+    USER_NOT_FOUND("U01", 404, "존재하지 않는 회원입니다."),
+    USER_UPDATE_SUCCESS("U02", 200, "회원 정보 수정이 완료되었습니다.");
+
+
+
+    private final String code;
+    private final int httpStatusCode;
+    private final String message;
+}

--- a/be/src/main/java/com/sharetravel/global/ApiResponseMessage.java
+++ b/be/src/main/java/com/sharetravel/global/ApiResponseMessage.java
@@ -1,0 +1,17 @@
+package com.sharetravel.global;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponseMessage {
+
+    private String code;
+    private String message;
+
+    public static ApiResponseMessage of(String code, String message) {
+        return new ApiResponseMessage(code, message);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/BaseTimeEntity.java
+++ b/be/src/main/java/com/sharetravel/global/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.sharetravel.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // BaseTimeEntity 클래스에 Auditing 기능 포함
+public abstract class BaseTimeEntity {
+
+    @CreatedDate // Entity 가 생성되어 저장될 때 시간이 자동 저장
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate // 조회한 Entity 값을 변경할 때 시간이 자동 저장
+    private LocalDateTime modifiedDate;
+}

--- a/be/src/main/java/com/sharetravel/global/CommonUtil.java
+++ b/be/src/main/java/com/sharetravel/global/CommonUtil.java
@@ -1,0 +1,14 @@
+package com.sharetravel.global;
+
+import org.springframework.http.ResponseEntity;
+
+public class CommonUtil {
+
+    public static ResponseEntity<ApiResponseMessage> getResponseEntity(ApiResponseCode responseCode) {
+        return ResponseEntity.status(responseCode.getHttpStatusCode())
+            .body(
+                ApiResponseMessage.of(responseCode.getCode(), responseCode.getMessage())
+            );
+    }
+
+}

--- a/be/src/main/java/com/sharetravel/global/ServletUtil.java
+++ b/be/src/main/java/com/sharetravel/global/ServletUtil.java
@@ -1,0 +1,92 @@
+package com.sharetravel.global;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sharetravel.global.auth.jwt.dto.LoginSuccessResponse;
+import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2UserInfo;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.StringUtils;
+
+public class ServletUtil {
+
+    public static final String ACCESS_TOKEN_TYPE = "Bearer ";
+    private static final String REFRESH_TOKEN_ID_COOKIE_NAME = "renew";
+    private static final int REFRESH_TOKEN_ID_DURATION = 60 * 10; // 10 minutes -> seconds
+
+    public static String parseAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ACCESS_TOKEN_TYPE)) {
+            return bearerToken.substring(ACCESS_TOKEN_TYPE.length());
+        }
+
+        throw new InvalidTokenException();
+    }
+
+    public static String parseRefreshTokenId(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(REFRESH_TOKEN_ID_COOKIE_NAME)) {
+                return cookie.getValue();
+            }
+        }
+
+        throw new InvalidTokenException();
+    }
+
+    public static void setLoginSuccessResponse(HttpServletResponse response, OAuth2UserInfo oAuth2UserInfo, String accessToken) throws IOException {
+        setResponseHeader(response, HttpStatus.OK.value());
+        setResponseBody(response, new LoginSuccessResponse(
+            oAuth2UserInfo.getName(),
+            oAuth2UserInfo.getEmail(),
+            oAuth2UserInfo.getNickName(),
+            oAuth2UserInfo.getPicture(),
+            accessToken)
+        );
+    }
+
+    public static void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        response.addHeader("Set-Cookie", getRefreshTokenCookieInfo(token));
+    }
+
+    // TODO : https 적용 시 Secure 설정 필요
+    private static String getRefreshTokenCookieInfo(String token) {
+        return ResponseCookie.from(REFRESH_TOKEN_ID_COOKIE_NAME, token)
+            .path("/api")
+            .httpOnly(true)
+            .sameSite("Strict")
+            .maxAge(REFRESH_TOKEN_ID_DURATION)
+            .build()
+            .toString();
+    }
+
+    public static void setApiResponse(HttpServletResponse response, ApiResponseCode apiResponseCode) throws IOException {
+        setResponseHeader(response, apiResponseCode.getHttpStatusCode());
+        setResponseBody(response, ApiResponseMessage.of(apiResponseCode.getCode(), apiResponseCode.getMessage()));
+    }
+
+    private static void setResponseHeader(HttpServletResponse response, int statusCode) {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(statusCode);
+    }
+
+    private static void setResponseBody(HttpServletResponse response, Object value)
+        throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        response.getWriter().write(
+            Objects.requireNonNull(
+                mapper.writeValueAsString(value)
+            )
+        );
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/argumentresolver/RefreshTokenId.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/argumentresolver/RefreshTokenId.java
@@ -1,0 +1,12 @@
+package com.sharetravel.global.auth.jwt.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RefreshTokenId {
+
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/argumentresolver/RefreshTokenIdArgumentResolver.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/argumentresolver/RefreshTokenIdArgumentResolver.java
@@ -1,0 +1,30 @@
+package com.sharetravel.global.auth.jwt.argumentresolver;
+
+import static com.sharetravel.global.ServletUtil.parseRefreshTokenId;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class RefreshTokenIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasRefreshTokenIdAnnotation = parameter.hasParameterAnnotation(RefreshTokenId.class);
+        boolean hasRefreshIdTokenType = String.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasRefreshTokenIdAnnotation && hasRefreshIdTokenType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        return parseRefreshTokenId(request);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/dto/AccessTokenResponse.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/dto/AccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.sharetravel.global.auth.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenResponse {
+    String accessToken;
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/dto/JwtAuthenticationResult.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/dto/JwtAuthenticationResult.java
@@ -1,0 +1,28 @@
+package com.sharetravel.global.auth.jwt.dto;
+
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+public class JwtAuthenticationResult extends AbstractAuthenticationToken {
+
+    private final Object principal;
+
+    public JwtAuthenticationResult(Long userId, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        principal = userId;
+    }
+
+    @Deprecated
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/dto/LoginSuccessResponse.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/dto/LoginSuccessResponse.java
@@ -1,0 +1,16 @@
+package com.sharetravel.global.auth.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginSuccessResponse {
+
+    private String name;
+    private String email;
+    private String nickName;
+    private String picture;
+    private String accessToken;
+
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/exception/HackedTokenException.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/exception/HackedTokenException.java
@@ -1,0 +1,8 @@
+package com.sharetravel.global.auth.jwt.exception;
+
+public class HackedTokenException extends RuntimeException {
+
+    public HackedTokenException() {
+        super("토큰이 도용되었습니다.");
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/exception/InvalidTokenException.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.sharetravel.global.auth.jwt.exception;
+
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다.");
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.sharetravel.global.auth.jwt.filter;
+
+import static com.sharetravel.global.ServletUtil.*;
+
+import com.sharetravel.global.auth.jwt.dto.JwtAuthenticationResult;
+import com.sharetravel.global.auth.jwt.service.AccessTokenService;
+import com.sharetravel.global.ApiResponseCode;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AccessTokenService accessTokenService;
+
+    private final String[][] excludePathAndMethod = {
+        {"/login", "GET"}, {"/oauth2", "GET"}, {"/api/token/reissue", "POST"}, {"/api/articles", "GET"}
+    };
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws IOException, ServletException {
+
+        try {
+            log.debug("JwtAuthenticationFilter is running...");
+
+            String token = parseAccessToken(request);
+
+            if (StringUtils.hasText(token) && !token.equalsIgnoreCase("null")) {
+                log.debug("Token is obtained...");
+
+                Claims claims = accessTokenService.validateAndGetClaims(token);
+                log.debug("Token is successfully validated...");
+
+                JwtAuthenticationResult jwtAuthenticationResult = accessTokenService.getJwtAuthenticationResult(claims);
+                jwtAuthenticationResult.setAuthenticated(true);
+                jwtAuthenticationResult.setDetails(request.getRemoteAddr());
+
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                securityContext.setAuthentication(jwtAuthenticationResult);
+                SecurityContextHolder.setContext(securityContext);
+            }
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
+            log.debug(e.getMessage());
+            setApiResponse(response, ApiResponseCode.TOKEN_INVALID);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        return Arrays.stream(excludePathAndMethod)
+            .anyMatch(e -> path.startsWith(e[0]) && e[1].equals(method));
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
@@ -1,0 +1,54 @@
+package com.sharetravel.global.auth.jwt.handler;
+
+import static com.sharetravel.global.ServletUtil.*;
+
+import com.sharetravel.global.CommonUtil;
+import com.sharetravel.global.auth.jwt.argumentresolver.RefreshTokenId;
+import com.sharetravel.global.auth.jwt.dto.AccessTokenResponse;
+import com.sharetravel.global.auth.jwt.exception.HackedTokenException;
+import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
+import com.sharetravel.global.auth.jwt.service.AccessTokenService;
+import com.sharetravel.global.ApiResponseCode;
+import com.sharetravel.global.ApiResponseMessage;
+import com.sharetravel.global.auth.jwt.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TokenHandler {
+
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/api/token/reissue")
+    public AccessTokenResponse reissue(@RefreshTokenId String refreshTokenId, HttpServletResponse response) {
+        String refreshToken = refreshTokenService.validateAndGetToken(refreshTokenId);
+
+        String renewedAccessToken = accessTokenService.renewAccessToken(refreshToken);
+
+        /*
+             리프레쉬 토큰을 이용하여 액세스 토큰을 재발급 받을 때마다 기존 리프레쉬 토큰 무효화 및 새로운 리프레쉬 토큰 발급
+             이때, 새로 발급된 리프레쉬 토큰의 유효기간은 이전과 동일하며, 이전 리프레쉬 토큰에 접근 시 모든 리프레쉬 토큰 무효화
+             이를 통해 리프레쉬 토큰 탈취 시 피해 파급 최소화
+        */
+        String renewedRefreshTokenId = refreshTokenService.renewRefreshToken(refreshTokenId, refreshToken);
+        addRefreshTokenCookie(response, renewedRefreshTokenId);
+
+        return new AccessTokenResponse(renewedAccessToken);
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ApiResponseMessage> handleInvalidTokenException() {
+        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_INVALID);
+    }
+
+    @ExceptionHandler(HackedTokenException.class)
+    public ResponseEntity<ApiResponseMessage> handleHackedTokenException() {
+        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_HACKED);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/repository/RefreshTokenRepository.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,35 @@
+package com.sharetravel.global.auth.jwt.repository;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class RefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveRefreshTokenById(String refreshTokenId, String refreshToken, long duration) {
+        redisTemplate.opsForValue().set(refreshTokenId, refreshToken, duration, TimeUnit.MILLISECONDS);
+    }
+
+    public Optional<String> findRefreshTokenById(String refreshTokenId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(refreshTokenId));
+    }
+
+    public void deleteByKey(String key) { // userId 또는 refreshTokenId
+        redisTemplate.delete(key);
+    }
+
+    public void addRefreshTokenIdByUserId(String userId, String refreshTokenId) {
+        redisTemplate.opsForSet().add(userId, refreshTokenId);
+    }
+
+    public Set<String> findAllRefreshTokenIdsByUserId(String userId) {
+        return redisTemplate.opsForSet().members(userId);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/service/AccessTokenService.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/service/AccessTokenService.java
@@ -1,0 +1,32 @@
+package com.sharetravel.global.auth.jwt.service;
+
+import com.sharetravel.global.auth.jwt.dto.JwtAuthenticationResult;
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AccessTokenService extends TokenService {
+
+    private static final long ACCESS_TOKEN_DURATION = 2 * 60_000; // 2 minutes
+
+    public String createAccessToken(String userId) {
+        return makeToken(userId, System.currentTimeMillis() + ACCESS_TOKEN_DURATION);
+    }
+
+    public String renewAccessToken(String token) {
+        return remakeToken(token, System.currentTimeMillis() + ACCESS_TOKEN_DURATION);
+    }
+
+    public Claims validateAndGetClaims(String token) {
+        return getClaims(token);
+    }
+
+    public JwtAuthenticationResult getJwtAuthenticationResult(Claims claims) {
+        return new JwtAuthenticationResult(
+            Long.parseLong(claims.getSubject()), AuthorityUtils.NO_AUTHORITIES
+        );
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/service/RefreshTokenService.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/service/RefreshTokenService.java
@@ -1,0 +1,90 @@
+package com.sharetravel.global.auth.jwt.service;
+
+import com.sharetravel.global.auth.jwt.exception.HackedTokenException;
+import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
+import com.sharetravel.global.auth.jwt.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService extends TokenService {
+
+    private static final long REFRESH_TOKEN_DURATION = 10 * 60_000; // 10 minutes -> milliseconds
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createRefreshToken(String userId) {
+        String refreshToken = makeToken(userId, System.currentTimeMillis() + REFRESH_TOKEN_DURATION);
+        String refreshTokenId = UUID.randomUUID().toString();
+        refreshTokenRepository.saveRefreshTokenById(refreshTokenId, refreshToken, REFRESH_TOKEN_DURATION); // 리프레쉬 토큰 아이디별 리프레쉬 토큰 값 저장
+        deleteRefreshTokensByUserId(userId);
+        refreshTokenRepository.addRefreshTokenIdByUserId(userId, refreshTokenId); // 해당 사용자 이름으로 새롭게 발행된 리프레쉬 토큰 아이디 값 저장
+
+        return refreshTokenId;
+    }
+
+    public String validateAndGetToken(String refreshTokenId) {
+        String refreshToken = refreshTokenRepository.findRefreshTokenById(refreshTokenId)
+            .orElseThrow(() -> {
+                throw new InvalidTokenException(); // 리프레쉬 토큰이 존재하지 않는 경우(리프레쉬 토큰이 만료됐거나 유효하지않은 리프레쉬 토큰 아이디로 접근한 경우)
+            });
+
+        Claims claims = getClaims(refreshToken);
+
+        if (claims.get(INVALIDATE, Boolean.class)) { // 리프레쉬 토큰 재사용이 감지된 경우
+            String userId = claims.getSubject();
+            deleteRefreshTokensByUserId(userId);
+
+            throw new HackedTokenException();
+        }
+
+        return refreshToken;
+    }
+
+    private void deleteRefreshTokensByUserId(String userId) {
+        Set<String> refreshTokenIds = refreshTokenRepository.findAllRefreshTokenIdsByUserId(userId);
+        for (String id : refreshTokenIds) { // 해당 사용자 이름으로 이전에 발행됐었던 모든 리프레쉬 토큰 값들 삭제
+            refreshTokenRepository.deleteByKey(id);
+        }
+
+        refreshTokenRepository.deleteByKey(userId); // 해당 사용자 이름으로 발행된 모든 리프레쉬 토큰 아이디 set 삭제
+    }
+
+    public String renewRefreshToken(String refreshTokenId, String refreshToken) {
+        Claims claims = getClaims(refreshToken);
+        String userId = claims.getSubject();
+        long expiration = claims.getExpiration().getTime();
+        long restDuration = expiration - System.currentTimeMillis();
+
+        String renewRefreshToken = remakeToken(refreshToken, expiration);
+        String renewRefreshTokenId = UUID.randomUUID().toString();
+
+        // 기존에 사용자에게 부여됐었던 리프레쉬 토큰 값을 무효화
+        String invalidToken = makeInvalidToken(refreshToken, expiration);
+        refreshTokenRepository.saveRefreshTokenById(refreshTokenId, invalidToken, restDuration);
+
+        // 새로운 리프레쉬 토큰 아이디와 토큰 값 저장
+        refreshTokenRepository.addRefreshTokenIdByUserId(userId, renewRefreshTokenId);
+        refreshTokenRepository.saveRefreshTokenById(renewRefreshTokenId, renewRefreshToken, restDuration);
+
+        return renewRefreshTokenId;
+    }
+
+    private String makeInvalidToken(String token, long expiration) {
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setClaims(getClaims(token))
+            .claim(INVALIDATE, true)
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(expiration))
+            .signWith(SECRET_KEY)
+            .compact();
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/service/TokenService.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/service/TokenService.java
@@ -1,0 +1,53 @@
+package com.sharetravel.global.auth.jwt.service;
+
+import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+
+public class TokenService {
+
+    private static final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithm.HS256;
+
+    protected static final Key SECRET_KEY = Keys.hmacShaKeyFor(Decoders.BASE64.decode(System.getenv("JWT_SECRET")));
+    protected static final String INVALIDATE = "invalidate";
+
+    protected Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    protected String makeToken(String userId, long expiration) {
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setSubject(userId)
+            .claim(INVALIDATE, false)
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(expiration))
+            .signWith(SECRET_KEY, SIGNATURE_ALGORITHM)
+            .compact();
+    }
+
+    protected String remakeToken(String token, long expiration) {
+        return Jwts.builder()
+            .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+            .setClaims(getClaims(token))
+            .setIssuedAt(new Date())
+            .setExpiration(new Date(expiration))
+            .signWith(SECRET_KEY, SIGNATURE_ALGORITHM)
+            .compact();
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/CustomOAuth2User.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/CustomOAuth2User.java
@@ -1,0 +1,28 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import java.util.Collection;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private final String userId;
+    private final String nickName;
+
+    public CustomOAuth2User(
+        Collection<? extends GrantedAuthority> authorities,
+        Map<String, Object> attributes, String nameAttributeKey, Long userId, String nickName) {
+        super(authorities, attributes, nameAttributeKey);
+        this.userId = String.valueOf(userId);
+        this.nickName = nickName;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getNickName() {
+        return nickName;
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/GoogleOAuth2UserInfo.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/GoogleOAuth2UserInfo.java
@@ -1,0 +1,54 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    private final String userId;
+    private final String nickName;
+    private static final String KEY_ID = "sub";
+    private static final String KEY_NAME = "name";
+    private static final String KEY_EMAIL = "email";
+    private static final String KEY_PICTURE = "picture";
+
+    public GoogleOAuth2UserInfo(String userId, String nickName, Map<String, Object> attributes) {
+        super(OAuth2Provider.GOOGLE, attributes);
+        this.userId = userId;
+        this.nickName = nickName;
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Long getId() {
+        return (Long) this.attributes.get(KEY_ID);
+    }
+
+    @Override
+    public String getName() {
+        return (String) this.attributes.get(KEY_NAME);
+    }
+
+    @Override
+    public String getNickName() {
+        return nickName;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) this.attributes.get(KEY_EMAIL);
+    }
+
+    @Override
+    public String getPicture() {
+        return (String) this.attributes.get(KEY_PICTURE);
+    }
+
+    @Override
+    public Map<String, Object> getEtcData() {
+        return this.attributes;
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/KakaoOAuth2UserInfo.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/KakaoOAuth2UserInfo.java
@@ -1,0 +1,58 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    private final String userId;
+    private final String nickName;
+    private static final String KEY_ID = "id";
+    private static final String KEY_NAME = "nickname";
+    private static final String KEY_EMAIL = "email";
+    private static final String KEY_PICTURE = "profile_image";
+    private static final String KEY_ETC_DATA = "kakao_account";
+
+    public KakaoOAuth2UserInfo(String userId, String nickName, Map<String, Object> attributes) {
+        super(OAuth2Provider.KAKAO, attributes);
+        this.userId = userId;
+        this.nickName = nickName;
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Long getId() {
+        return (Long) this.attributes.get(KEY_ID);
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) this.attributes.get("properties");
+        return (String) properties.get(KEY_NAME);
+    }
+
+    @Override
+    public String getNickName() {
+        return nickName;
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) this.attributes.get("kakao_account");
+        return (String) kakaoAccount.get(KEY_EMAIL);
+    }
+
+    @Override
+    public String getPicture() {
+        Map<String, Object> properties = (Map<String, Object>) this.attributes.get("properties");
+        return (String) properties.get(KEY_PICTURE);
+    }
+
+    @Override
+    public Map<String, Object> getEtcData() {
+        return (Map<String, Object>) this.attributes.get(KEY_ETC_DATA);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/NaverOAuth2UserInfo.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/NaverOAuth2UserInfo.java
@@ -1,0 +1,55 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    private final String userId;
+    private final String nickName;
+    private static final String KEY_ID = "id";
+    private static final String KEY_NAME = "name";
+    private static final String KEY_EMAIL = "email";
+    private static final String KEY_PICTURE = "profile_image";
+    private static final String KEY_ETC_DATA = "response";
+
+    public NaverOAuth2UserInfo(String userId, String nickName, Map<String, Object> attributes) {
+        super(OAuth2Provider.NAVER, (Map<String, Object>) attributes.get("response"));
+        this.userId = userId;
+        this.nickName = nickName;
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Long getId() {
+        return (Long) this.attributes.get(KEY_ID);
+    }
+
+    @Override
+    public String getName() {
+        return (String) this.attributes.get(KEY_NAME);
+    }
+
+    @Override
+    public String getNickName() {
+        return nickName;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) this.attributes.get(KEY_EMAIL);
+    }
+
+    @Override
+    public String getPicture() {
+        return (String) this.attributes.get(KEY_PICTURE);
+    }
+
+    @Override
+    public Map<String, Object> getEtcData() {
+        return (Map<String, Object>) this.attributes.get(KEY_ETC_DATA);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuth2Provider.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuth2Provider.java
@@ -1,0 +1,5 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+public enum OAuth2Provider {
+    GOOGLE, NAVER, KAKAO, NONE;
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuth2UserInfo.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public abstract class OAuth2UserInfo {
+
+    protected OAuth2Provider provider;
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(OAuth2Provider provider, Map<String, Object> attributes) {
+        this.provider = provider;
+        this.attributes = attributes;
+    }
+
+    public abstract String getUserId();
+    public abstract Long getId();
+    public abstract String getName();
+    public abstract String getNickName();
+    public abstract String getEmail();
+    public abstract String getPicture();
+    public abstract Map<String, Object> getEtcData();
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuthAttributes.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/dto/OAuthAttributes.java
@@ -1,0 +1,92 @@
+package com.sharetravel.global.auth.oauth2.dto;
+
+import com.sharetravel.domain.user.entity.Role;
+import com.sharetravel.domain.user.entity.User;
+import com.sharetravel.global.auth.oauth2.exception.UnsupportedOAuth2ProviderException;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final String name;
+    private final String nickName;
+    private final String email;
+    private final OAuth2Provider provider;
+    private final String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey,
+        String name, String nickName, String email, OAuth2Provider provider, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.nickName = nickName;
+        this.email = email;
+        this.provider = provider;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if ("google".equals(registrationId)) {
+            return ofGoogle(userNameAttributeName, attributes);
+        } else if ("naver".equals(registrationId)) {
+            return ofNaver(userNameAttributeName, attributes);
+        } else if ("kakao".equals(registrationId)) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+
+        throw new UnsupportedOAuth2ProviderException();
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+            .name((String) attributes.get("name"))
+            .email((String) attributes.get("email"))
+            .provider(OAuth2Provider.GOOGLE)
+            .picture((String) attributes.get("picture"))
+            .attributes(attributes)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+            .name((String) response.get("name"))
+            .email((String) response.get("email"))
+            .provider(OAuth2Provider.NAVER)
+            .picture((String) response.get("profile_image"))
+            .attributes(response)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        return OAuthAttributes.builder()
+            .name((String) properties.get("nickname"))
+            .email((String) kakaoAccount.get("email"))
+            .provider(OAuth2Provider.KAKAO)
+            .picture((String) properties.get("profile_image"))
+            .attributes(kakaoAccount)
+            .nameAttributeKey(userNameAttributeName)
+            .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+            .name(name)
+            .email(email)
+            .provider(provider)
+            .picture(picture)
+            .role(Role.GUEST)
+            .build();
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/exception/UnsupportedOAuth2ProviderException.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/exception/UnsupportedOAuth2ProviderException.java
@@ -1,0 +1,11 @@
+package com.sharetravel.global.auth.oauth2.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class UnsupportedOAuth2ProviderException extends AuthenticationException {
+
+    public UnsupportedOAuth2ProviderException() {
+        super("지원되지 않는 OAuth Provider 입니다.");
+    }
+
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationFailureHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,23 @@
+package com.sharetravel.global.auth.oauth2.handler;
+
+import com.sharetravel.global.ApiResponseCode;
+import com.sharetravel.global.ServletUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException {
+        System.out.println(exception.getCause());
+        System.out.println(exception.getMessage());
+        response.setStatus(ApiResponseCode.OAUTH2_LOGIN_FAIL.getHttpStatusCode());
+        ServletUtil.setApiResponse(response, ApiResponseCode.OAUTH2_LOGIN_FAIL);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,40 @@
+package com.sharetravel.global.auth.oauth2.handler;
+
+import static com.sharetravel.global.ServletUtil.*;
+
+import com.sharetravel.global.auth.jwt.service.AccessTokenService;
+import com.sharetravel.global.auth.jwt.service.RefreshTokenService;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2UserInfo;
+import com.sharetravel.global.auth.oauth2.utils.OAuth2UserInfoUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoUtil.getOAuth2UserInfo(
+            (OAuth2AuthenticationToken) authentication);
+
+        String userId = oAuth2UserInfo.getUserId();
+
+        String accessToken = accessTokenService.createAccessToken(userId);
+        String refreshTokenId = refreshTokenService.createRefreshToken(userId);
+
+        setLoginSuccessResponse(response, oAuth2UserInfo, accessToken);
+        addRefreshTokenCookie(response, refreshTokenId);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.sharetravel.global.auth.oauth2.service;
+
+import com.sharetravel.global.auth.oauth2.dto.CustomOAuth2User;
+import com.sharetravel.global.auth.oauth2.dto.OAuthAttributes;
+import com.sharetravel.domain.user.entity.User;
+import com.sharetravel.domain.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+            .getUserInfoEndpoint().getUserNameAttributeName();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        OAuthAttributes oAuthAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, attributes);
+
+        User user = saveOrUpdate(oAuthAttributes);
+
+        return new CustomOAuth2User(
+            Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+            attributes,
+            oAuthAttributes.getNameAttributeKey(),
+            user.getId(),
+            user.getNickName()
+        );
+    }
+
+    private User saveOrUpdate(OAuthAttributes attributes) {
+        User user = userRepository.findByEmailAndProvider(attributes.getEmail(), attributes.getProvider())
+            .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/utils/OAuth2UserInfoUtil.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/utils/OAuth2UserInfoUtil.java
@@ -1,0 +1,31 @@
+package com.sharetravel.global.auth.oauth2.utils;
+
+import com.sharetravel.global.auth.oauth2.dto.CustomOAuth2User;
+import com.sharetravel.global.auth.oauth2.dto.GoogleOAuth2UserInfo;
+import com.sharetravel.global.auth.oauth2.dto.KakaoOAuth2UserInfo;
+import com.sharetravel.global.auth.oauth2.dto.NaverOAuth2UserInfo;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2UserInfo;
+import com.sharetravel.global.auth.oauth2.exception.UnsupportedOAuth2ProviderException;
+import java.util.Map;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+
+public class OAuth2UserInfoUtil {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(OAuth2AuthenticationToken auth2AuthenticationToken) {
+        String registrationId = auth2AuthenticationToken.getAuthorizedClientRegistrationId();
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) auth2AuthenticationToken.getPrincipal();
+        String userId = oAuth2User.getUserId();
+        String nickName = oAuth2User.getNickName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        if ("google".equals(registrationId)) {
+            return new GoogleOAuth2UserInfo(userId, nickName, attributes);
+        } else if ("naver".equals(registrationId)) {
+            return new NaverOAuth2UserInfo(userId, nickName, attributes);
+        } else if ("kakao".equals(registrationId)) {
+            return new KakaoOAuth2UserInfo(userId, nickName, attributes);
+        }
+
+        throw new UnsupportedOAuth2ProviderException();
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/config/MvcConfig.java
+++ b/be/src/main/java/com/sharetravel/global/config/MvcConfig.java
@@ -1,0 +1,16 @@
+package com.sharetravel.global.config;
+
+import com.sharetravel.global.auth.jwt.argumentresolver.RefreshTokenIdArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new RefreshTokenIdArgumentResolver());
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/config/RedisConfig.java
+++ b/be/src/main/java/com/sharetravel/global/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.sharetravel.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/be/src/main/java/com/sharetravel/global/config/SecurityConfig.java
+++ b/be/src/main/java/com/sharetravel/global/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package com.sharetravel.global.config;
+
+import com.sharetravel.global.auth.oauth2.handler.CustomAuthenticationFailureHandler;
+import com.sharetravel.global.auth.oauth2.handler.CustomAuthenticationSuccessHandler;
+import com.sharetravel.global.auth.oauth2.service.CustomOAuth2UserService;
+import com.sharetravel.global.auth.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationSuccessHandler successHandler;
+    private final CustomAuthenticationFailureHandler failureHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf().disable().headers().frameOptions()
+            .disable() // h2-console 화면 사용 위해 해당 옵션 disable
+        .and()
+            .httpBasic().disable() // 토큰 사용하므로 basic disable
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 기반이 아님을 선언
+        .and()
+            .oauth2Login() // OAuth2  로그인 설정 시작점
+            .userInfoEndpoint() // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때 설정 담당
+            .userService(customOAuth2UserService)
+        .and()
+            .successHandler(successHandler)
+            .failureHandler(failureHandler)
+        .and()
+            .addFilterAfter(jwtAuthenticationFilter, CorsFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("http://localhost:3000");
+        configuration.addAllowedMethod("GET");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(
+            true); // Cross Origin 에 요청을 보낼 때 요청에 인증(credential) 정보를 담아서 보낼 수 있는지 결정하는 항목
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/articles/**", configuration);
+
+        return source;
+    }
+}

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -1,1 +1,24 @@
-
+spring:
+  profiles:
+    include: oauth
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true # 하이버네이트가 DB에 날리는 모든 쿼리(DDL, DML)를 콘솔창에 보여줌
+        format_sql: true # SQL 예쁘게 보기
+    hibernate:
+      ddl-auto: create
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+logging:
+  level:
+    org:
+      springframework:
+        security: INFO


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ Spring Security 활용 OAuth2 연동 로그인 기능
  + Provider : Google, Naver, Kakao
  + 확장성 있는 설계로 추후에 다른 Provider 추가 용이
+ JWT 활용 사용자 권한 부여(인가) 기능
  + Access Token 탈취 피해 감소 위해 Access Token 의 유효시간을 낮추고 Refresh Token 을 통해 Access Token 재발급
  + RTR 기법을 통해 Refresh Token 탈취 피해 감소 노력(Redis 연동)

## 🔎 참고 사항

+ Redis 를 연동하므로 로컬 테스트 시 로컬에 Redis 설치 필요(or 도커 활용)
+ JWT SECRET, DB URL/PASSWORD, REDIS HOST 의 경우 시스템 환경변수로 처리
+ OAuth2 관련 클라이언트 ID 및 시크릿 키는 별도의 application.yml 파일로 관리하므로 로컬 테스트 시 해당 파일 취득 요망
+ 추후 https 적용 후 리프레쉬 토큰을 담은 쿠키에 Secure 속성 주어야 함