### PR TITLE
[Infra/hotfix] 수동 배포 테스트 위한 별도 workflow 파일 생성

### DIFF
--- a/.github/workflows/manual-deploy-be.yml
+++ b/.github/workflows/manual-deploy-be.yml
@@ -1,8 +1,7 @@
-name: BACKEND CI/CD
+name: Munual Deploy Backend
 
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -10,7 +9,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'be')
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 당초 기존 ci/cd 파일 을 통한 수동 배포 위해 트리거로 workflow_dispatch 를 추가했었으나,
+ merged 되는 브랜치 이름이 be 로 시작하지 않으면 빌드 작업이 수행되지 않는 문제점 존재
+ 따라서 수동 배포 테스트 위한 별도의 workflow 파일을 생성하였음

## 🔎 참고 사항

+ 해당 내용 구두로 전달 후 자체 승인 및 merge
