### PR TITLE
[Be/feature/auth] 액세스 토큰 전달 방식 롤백 처리

### DIFF
--- a/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
+++ b/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
@@ -11,10 +11,11 @@ public enum ApiResponseCode {
     OAUTH2_LOGIN_FAIL("A02", 401, "로그인이 실패했습니다."),
     TOKEN_INVALID("A03", 401, "유효하지 않은 토큰입니다."),
     TOKEN_HACKED("A04", 401, "토큰 도용이 의심됩니다."),
-    TOKEN_REFRESHED("A05", 200, "액세스 토큰이 재발급되었습니다."),
 
     USER_NOT_FOUND("U01", 404, "존재하지 않는 회원입니다."),
     USER_UPDATE_SUCCESS("U02", 200, "회원 정보 수정이 완료되었습니다.");
+
+
 
     private final String code;
     private final int httpStatusCode;

--- a/be/src/main/java/com/sharetravel/global/ServletUtil.java
+++ b/be/src/main/java/com/sharetravel/global/ServletUtil.java
@@ -42,9 +42,9 @@ public class ServletUtil {
         throw new InvalidTokenException();
     }
 
-    public static void addTokenToCookie(HttpServletResponse response, String accessToken, String refreshTokenId) {
+    public static void addTokenToCookie(HttpServletResponse response, String accessToken, String refreshToken) {
         response.addCookie(getAccessTokenCookie(accessToken));
-        response.addCookie(getRefreshTokenIdCookie(refreshTokenId));
+        response.addCookie(getRefreshTokenIdCookie(refreshToken));
     }
 
     // TODO : https 적용 시 Secure 설정 필요

--- a/be/src/main/java/com/sharetravel/global/ServletUtil.java
+++ b/be/src/main/java/com/sharetravel/global/ServletUtil.java
@@ -1,31 +1,31 @@
 package com.sharetravel.global;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sharetravel.global.auth.jwt.dto.LoginSuccessResponse;
 import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
+import com.sharetravel.global.auth.oauth2.dto.OAuth2UserInfo;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Objects;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.StringUtils;
 
 public class ServletUtil {
 
-    public static final String ACCESS_TOKEN_HEADER_TYPE = "Bearer ";
-
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "auth";
+    public static final String ACCESS_TOKEN_TYPE = "Bearer ";
     private static final String REFRESH_TOKEN_ID_COOKIE_NAME = "renew";
-
-    private static final int ACCESS_TOKEN_COOKIE_DURATION = 10; // 10 seconds
-    private static final int REFRESH_TOKEN_ID_COOKIE_DURATION = 600; // 600 seconds (= 10 minutes)
+    private static final int REFRESH_TOKEN_ID_DURATION = 60 * 10; // 10 minutes -> seconds
 
     public static String parseAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ACCESS_TOKEN_HEADER_TYPE)) {
-            return bearerToken.substring(ACCESS_TOKEN_HEADER_TYPE.length());
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ACCESS_TOKEN_TYPE)) {
+            return bearerToken.substring(ACCESS_TOKEN_TYPE.length());
         }
 
         throw new InvalidTokenException();
@@ -42,31 +42,30 @@ public class ServletUtil {
         throw new InvalidTokenException();
     }
 
-    public static void addTokenToCookie(HttpServletResponse response, String accessToken, String refreshToken) {
-        response.addCookie(getAccessTokenCookie(accessToken));
-        response.addCookie(getRefreshTokenIdCookie(refreshToken));
+    public static void setLoginSuccessResponse(HttpServletResponse response, OAuth2UserInfo oAuth2UserInfo, String accessToken) throws IOException {
+        setResponseHeader(response, HttpStatus.OK.value());
+        setResponseBody(response, new LoginSuccessResponse(
+            oAuth2UserInfo.getName(),
+            oAuth2UserInfo.getEmail(),
+            oAuth2UserInfo.getNickName(),
+            oAuth2UserInfo.getPicture(),
+            accessToken)
+        );
+    }
+
+    public static void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        response.addHeader("Set-Cookie", getRefreshTokenCookieInfo(token));
     }
 
     // TODO : https 적용 시 Secure 설정 필요
-    private static Cookie getAccessTokenCookie(String accessToken) {
-        Cookie refreshTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setAttribute("SameSite", "Strict");
-        refreshTokenCookie.setMaxAge(ACCESS_TOKEN_COOKIE_DURATION);
-
-        return refreshTokenCookie;
-    }
-
-    // TODO : https 적용 시 Secure 설정 필요
-    private static Cookie getRefreshTokenIdCookie(String refreshTokenId) {
-        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_ID_COOKIE_NAME, refreshTokenId);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setAttribute("SameSite", "Strict");
-        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_ID_COOKIE_DURATION);
-
-        return refreshTokenCookie;
+    private static String getRefreshTokenCookieInfo(String token) {
+        return ResponseCookie.from(REFRESH_TOKEN_ID_COOKIE_NAME, token)
+            .path("/api")
+            .httpOnly(true)
+            .sameSite("Strict")
+            .maxAge(REFRESH_TOKEN_ID_DURATION)
+            .build()
+            .toString();
     }
 
     public static void setApiResponse(HttpServletResponse response, ApiResponseCode apiResponseCode) throws IOException {

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
@@ -1,9 +1,10 @@
 package com.sharetravel.global.auth.jwt.handler;
 
-import static com.sharetravel.global.CommonUtil.getResponseEntity;
 import static com.sharetravel.global.ServletUtil.*;
 
+import com.sharetravel.global.CommonUtil;
 import com.sharetravel.global.auth.jwt.argumentresolver.RefreshTokenId;
+import com.sharetravel.global.auth.jwt.dto.AccessTokenResponse;
 import com.sharetravel.global.auth.jwt.exception.HackedTokenException;
 import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
 import com.sharetravel.global.auth.jwt.service.AccessTokenService;
@@ -25,7 +26,7 @@ public class TokenHandler {
     private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/api/token/reissue")
-    public ResponseEntity<ApiResponseMessage> reissue(@RefreshTokenId String refreshTokenId, HttpServletResponse response) {
+    public AccessTokenResponse reissue(@RefreshTokenId String refreshTokenId, HttpServletResponse response) {
         String refreshToken = refreshTokenService.validateAndGetToken(refreshTokenId);
 
         String renewedAccessToken = accessTokenService.renewAccessToken(refreshToken);
@@ -36,18 +37,18 @@ public class TokenHandler {
              이를 통해 리프레쉬 토큰 탈취 시 피해 파급 최소화
         */
         String renewedRefreshTokenId = refreshTokenService.renewRefreshToken(refreshTokenId, refreshToken);
-        addTokenToCookie(response, renewedAccessToken, renewedRefreshTokenId);
+        addRefreshTokenCookie(response, renewedRefreshTokenId);
 
-        return getResponseEntity(ApiResponseCode.TOKEN_REFRESHED);
+        return new AccessTokenResponse(renewedAccessToken);
     }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiResponseMessage> handleInvalidTokenException() {
-        return getResponseEntity(ApiResponseCode.TOKEN_INVALID);
+        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_INVALID);
     }
 
     @ExceptionHandler(HackedTokenException.class)
     public ResponseEntity<ApiResponseMessage> handleHackedTokenException() {
-        return getResponseEntity(ApiResponseCode.TOKEN_HACKED);
+        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_HACKED);
     }
 }

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
@@ -34,7 +34,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         String accessToken = accessTokenService.createAccessToken(userId);
         String refreshTokenId = refreshTokenService.createRefreshToken(userId);
 
-        addTokenToCookie(response, accessToken, refreshTokenId);
-        response.sendRedirect("http://localhost:3000");
+        setLoginSuccessResponse(response, oAuth2UserInfo, accessToken);
+        addRefreshTokenCookie(response, refreshTokenId);
     }
 }


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 당초 서버에서 액세스 토큰 등 사용자 정보를 쿠키로 클라이언트에 응답하려고 했었으나, 리다이렉션으로 인해 모든 데이터가 소멸되는 문제점 존재
+ 이에, OAuth2 리다이렉트 targetUrl 을 서버로 하는 것이 아니라 클라이언트로 처리하고자 하며, 이전 작업분을 롤백하고자 함 (이전 PR 작업분 Revert)

## 🔎 참고 사항

+ 없음
