### PR TITLE
[Be/feature/auth] OAuth2 로그인 완료 시 사용자 전달 방식 개선

### DIFF
--- a/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
+++ b/be/src/main/java/com/sharetravel/global/ApiResponseCode.java
@@ -11,6 +11,7 @@ public enum ApiResponseCode {
     OAUTH2_LOGIN_FAIL("A02", 401, "로그인이 실패했습니다."),
     TOKEN_INVALID("A03", 401, "유효하지 않은 토큰입니다."),
     TOKEN_HACKED("A04", 401, "토큰 도용이 의심됩니다."),
+    TOKEN_REFRESHED("A05", 200, "액세스 토큰이 재발급되었습니다."),
 
     USER_NOT_FOUND("U01", 404, "존재하지 않는 회원입니다."),
     USER_UPDATE_SUCCESS("U02", 200, "회원 정보 수정이 완료되었습니다.");

--- a/be/src/main/java/com/sharetravel/global/ServletUtil.java
+++ b/be/src/main/java/com/sharetravel/global/ServletUtil.java
@@ -1,31 +1,31 @@
 package com.sharetravel.global;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sharetravel.global.auth.jwt.dto.LoginSuccessResponse;
 import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
-import com.sharetravel.global.auth.oauth2.dto.OAuth2UserInfo;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Objects;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 import org.springframework.util.StringUtils;
 
 public class ServletUtil {
 
-    public static final String ACCESS_TOKEN_TYPE = "Bearer ";
+    private static final String ACCESS_TOKEN_HEADER_TYPE = "Bearer ";
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "auth";
     private static final String REFRESH_TOKEN_ID_COOKIE_NAME = "renew";
-    private static final int REFRESH_TOKEN_ID_DURATION = 60 * 10; // 10 minutes -> seconds
+
+    private static final int ACCESS_TOKEN_COOKIE_DURATION = 5; // 10 seconds
+    private static final int REFRESH_TOKEN_ID_COOKIE_DURATION = 600; // 600 seconds (= 10 minutes)
 
     public static String parseAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ACCESS_TOKEN_TYPE)) {
-            return bearerToken.substring(ACCESS_TOKEN_TYPE.length());
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ACCESS_TOKEN_HEADER_TYPE)) {
+            return bearerToken.substring(ACCESS_TOKEN_HEADER_TYPE.length());
         }
 
         throw new InvalidTokenException();
@@ -42,30 +42,31 @@ public class ServletUtil {
         throw new InvalidTokenException();
     }
 
-    public static void setLoginSuccessResponse(HttpServletResponse response, OAuth2UserInfo oAuth2UserInfo, String accessToken) throws IOException {
-        setResponseHeader(response, HttpStatus.OK.value());
-        setResponseBody(response, new LoginSuccessResponse(
-            oAuth2UserInfo.getName(),
-            oAuth2UserInfo.getEmail(),
-            oAuth2UserInfo.getNickName(),
-            oAuth2UserInfo.getPicture(),
-            accessToken)
-        );
-    }
-
-    public static void addRefreshTokenCookie(HttpServletResponse response, String token) {
-        response.addHeader("Set-Cookie", getRefreshTokenCookieInfo(token));
+    public static void addTokenToCookie(HttpServletResponse response, String accessToken, String refreshTokenId) {
+        response.addCookie(getAccessTokenCookie(accessToken));
+        response.addCookie(getRefreshTokenIdCookie(refreshTokenId));
     }
 
     // TODO : https 적용 시 Secure 설정 필요
-    private static String getRefreshTokenCookieInfo(String token) {
-        return ResponseCookie.from(REFRESH_TOKEN_ID_COOKIE_NAME, token)
-            .path("/api")
-            .httpOnly(true)
-            .sameSite("Strict")
-            .maxAge(REFRESH_TOKEN_ID_DURATION)
-            .build()
-            .toString();
+    private static Cookie getAccessTokenCookie(String accessToken) {
+        Cookie refreshTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(false);
+        refreshTokenCookie.setAttribute("SameSite", "Strict");
+        refreshTokenCookie.setMaxAge(ACCESS_TOKEN_COOKIE_DURATION);
+
+        return refreshTokenCookie;
+    }
+
+    // TODO : https 적용 시 Secure 설정 필요
+    private static Cookie getRefreshTokenIdCookie(String refreshTokenId) {
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_ID_COOKIE_NAME, refreshTokenId);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setAttribute("SameSite", "Strict");
+        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_ID_COOKIE_DURATION);
+
+        return refreshTokenCookie;
     }
 
     public static void setApiResponse(HttpServletResponse response, ApiResponseCode apiResponseCode) throws IOException {

--- a/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/jwt/handler/TokenHandler.java
@@ -1,10 +1,9 @@
 package com.sharetravel.global.auth.jwt.handler;
 
+import static com.sharetravel.global.CommonUtil.getResponseEntity;
 import static com.sharetravel.global.ServletUtil.*;
 
-import com.sharetravel.global.CommonUtil;
 import com.sharetravel.global.auth.jwt.argumentresolver.RefreshTokenId;
-import com.sharetravel.global.auth.jwt.dto.AccessTokenResponse;
 import com.sharetravel.global.auth.jwt.exception.HackedTokenException;
 import com.sharetravel.global.auth.jwt.exception.InvalidTokenException;
 import com.sharetravel.global.auth.jwt.service.AccessTokenService;
@@ -26,7 +25,7 @@ public class TokenHandler {
     private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/api/token/reissue")
-    public AccessTokenResponse reissue(@RefreshTokenId String refreshTokenId, HttpServletResponse response) {
+    public ResponseEntity<ApiResponseMessage> reissue(@RefreshTokenId String refreshTokenId, HttpServletResponse response) {
         String refreshToken = refreshTokenService.validateAndGetToken(refreshTokenId);
 
         String renewedAccessToken = accessTokenService.renewAccessToken(refreshToken);
@@ -37,18 +36,18 @@ public class TokenHandler {
              이를 통해 리프레쉬 토큰 탈취 시 피해 파급 최소화
         */
         String renewedRefreshTokenId = refreshTokenService.renewRefreshToken(refreshTokenId, refreshToken);
-        addRefreshTokenCookie(response, renewedRefreshTokenId);
+        addTokenToCookie(response, renewedAccessToken, renewedRefreshTokenId);
 
-        return new AccessTokenResponse(renewedAccessToken);
+        return getResponseEntity(ApiResponseCode.TOKEN_REFRESHED);
     }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiResponseMessage> handleInvalidTokenException() {
-        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_INVALID);
+        return getResponseEntity(ApiResponseCode.TOKEN_INVALID);
     }
 
     @ExceptionHandler(HackedTokenException.class)
     public ResponseEntity<ApiResponseMessage> handleHackedTokenException() {
-        return CommonUtil.getResponseEntity(ApiResponseCode.TOKEN_HACKED);
+        return getResponseEntity(ApiResponseCode.TOKEN_HACKED);
     }
 }

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
@@ -34,7 +34,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         String accessToken = accessTokenService.createAccessToken(userId);
         String refreshTokenId = refreshTokenService.createRefreshToken(userId);
 
-        setLoginSuccessResponse(response, oAuth2UserInfo, accessToken);
-        addRefreshTokenCookie(response, refreshTokenId);
+        addTokenToCookie(response, accessToken, refreshTokenId);
+        response.sendRedirect("http://localhost:3000");
     }
 }

--- a/be/src/main/java/com/sharetravel/global/config/SecurityConfig.java
+++ b/be/src/main/java/com/sharetravel/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
             true); // Cross Origin 에 요청을 보낼 때 요청에 인증(credential) 정보를 담아서 보낼 수 있는지 결정하는 항목
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/api/articles/**", configuration);
+        source.registerCorsConfiguration("/**", configuration);
 
         return source;
     }

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -22,19 +22,18 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "http://localhost:3000/login/{registrationId}"
             scope: profile,email
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: "http://localhost:3000/login/{registrationId}"
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization_grant_type: authorization_code
             scope: name,email,profile_image
             client-name: naver
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: "http://localhost:3000/login/{registrationId}"
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             scope: profile_nickname,profile_image,account_email


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 당초, OAuth2 리다이렉트 URI 를 클라이언트 단으로 지정한 후, 서버에 별도의 API 로 인증 코드를 전달하여, 처리하려고 했으나, Spring Security 에서는 기본적으로 설정한 리다이렉트 URI 를 엔드 포인트를 기점으로 인증 작업을 처리
+ 이에, OAuth2 로그인 완료 시 서버에서 리다이렉션과 함께 쿠키를 응답을 한 후, 클라이언트에서 특정 페이지로 라우팅한 후 해당 페이지에서 사용자 정보 및 토큰 값을 Vuex 를 통해 관리하도록 개선하고자 함
  + 이때, 쿠키의 만료 시간은 매우 짧음

## 🔎 참고 사항

+ 클라이언트 측에서 OAuth2 로그인 완료 시 사용자 정보 및 토큰을 Vuex 에 저장하는 것까지 확인
