### PR TITLE
[Be/feature/travel] 여행지 키워드 조회 시 데이터 캐싱 처리

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail:3.1.0'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: '3.0.6'
 
 	/* Tool */
 	compileOnly 'org.projectlombok:lombok'

--- a/be/src/main/java/com/sharetravel/ServerApplication.java
+++ b/be/src/main/java/com/sharetravel/ServerApplication.java
@@ -2,8 +2,10 @@ package com.sharetravel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching // 캐시 기능 사용
 @EnableJpaAuditing // JPA Auditing 활성화
 @SpringBootApplication
 public class ServerApplication {

--- a/be/src/main/java/com/sharetravel/domain/board/entity/Board.java
+++ b/be/src/main/java/com/sharetravel/domain/board/entity/Board.java
@@ -38,7 +38,7 @@ public class Board extends BaseTimeEntity {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Column(length = 100, nullable = false)
+    @Column(name = "subtitle", length = 100, nullable = false)
     private String subTitle;
 
     @Column(length = 1500, nullable = false)

--- a/be/src/main/java/com/sharetravel/domain/travelkeyword/dto/TravelKeywordResponseDto.java
+++ b/be/src/main/java/com/sharetravel/domain/travelkeyword/dto/TravelKeywordResponseDto.java
@@ -1,6 +1,7 @@
 package com.sharetravel.domain.travelkeyword.dto;
 
 import com.sharetravel.domain.travelkeyword.entity.TravelKeyword;
+import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class TravelKeywordResponseDto {
+public class TravelKeywordResponseDto implements Serializable {
 
     private Long id;
     private String name;

--- a/be/src/main/java/com/sharetravel/domain/travelkeyword/service/TravelKeywordService.java
+++ b/be/src/main/java/com/sharetravel/domain/travelkeyword/service/TravelKeywordService.java
@@ -3,6 +3,7 @@ package com.sharetravel.domain.travelkeyword.service;
 import com.sharetravel.domain.travelkeyword.dto.TravelKeywordResponseDto;
 import com.sharetravel.domain.travelkeyword.repository.TravelKeywordRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ public class TravelKeywordService {
 
     private final TravelKeywordRepository travelKeywordRepository;
 
+    @Cacheable("travelKeyword")
     @Transactional(readOnly = true)
     public List<TravelKeywordResponseDto> getTravelKeywords() {
         return travelKeywordRepository.findAll()

--- a/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
+++ b/be/src/main/java/com/sharetravel/global/auth/oauth2/handler/CustomAuthenticationSuccessHandler.java
@@ -38,6 +38,6 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         response.addCookie(getAccessTokenCookie(accessToken));
         response.addCookie(getRefreshTokenIdCookie(refreshTokenId));
 
-        response.sendRedirect("https://localhost:3000");
+        response.sendRedirect(System.getenv("CLIENT_URL"));
     }
 }


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 여행지 키워드의 경우 자주 바뀌는 데이터가 아니기 때문에 캐싱 처리함이 성능 최적화에 유리하므로, 데이터 캐싱 처리

## 🔎 참고 사항

+ (주의) OAuth2 로그인 완료 시 서버에서 클라이언트로 리다이렉션하는 응답 주소를 별도 환경 변수 처리하였으니 유의하시길 바랍니다.
